### PR TITLE
Fix a typo in gibMacOS

### DIFF
--- a/gibMacOS.command
+++ b/gibMacOS.command
@@ -397,7 +397,7 @@ class gibMacOS:
             print(var1)
             print(var2)
         print("")
-        print("M. Change Max-OS Version (Currently 10.{})".format(self.current_macos))
+        print("M. Change macOS Version (Currently 10.{})".format(self.current_macos))
         print("C. Change Catalog (Currently {})".format(self.current_catalog))
         if sys.platform.lower() == "darwin":
             pad += 2


### PR DESCRIPTION
Changed:
"Change Max-OS version"
to:
"Change macOS version