### PR TITLE
Update gibMacOS.command

### DIFF
--- a/gibMacOS.command
+++ b/gibMacOS.command
@@ -285,7 +285,7 @@ class gibMacOS:
                 done.append({"name":os.path.basename(x), "status":False})
         succeeded = [x for x in done if x["status"]]
         failed    = [x for x in done if not x["status"]]
-        self.u.head("Downloaded {} of {}".format(len(succeeded), len(dl_list)))
+        self.u.head("Downloaded {} of {} /n".format(len(succeeded), len(dl_list)))
         print("")
         print("Succeeded:")
         if len(succeeded):


### PR DESCRIPTION
updated gibmacos.command so that when downloaded amount appears, it takes a new line every time. Previously it would not take a new line and just stack up making it hard to read