### PR TITLE
removed a singleton-comparison pitfall

### DIFF
--- a/MakeInstall.py
+++ b/MakeInstall.py
@@ -655,7 +655,7 @@ class WinUSB:
         # Some users are having issues with the "partitions" key not populating - possibly a 3rd party disk management soft?
         # Possibly a bad USB?
         # We'll see if the key exists - if not, we'll throw an error.
-        if self.d.disks[str(disk["index"])].get("partitions",None) == None:
+        if self.d.disks[str(disk["index"])].get("partitions",None) is None:
             # No partitions found.
             shutil.rmtree(temp,ignore_errors=True)
             print("No partitions located on disk!")


### PR DESCRIPTION
**The problem**
In Python when comparing to singletons, the use of the operator 'is' instead of '==' is encouraged.
This pitfall was detected using Pylint, under the code C0121
More about it can be found here: https://vald-phoenix.github.io/pylint-errors/plerr/errors/basic/C0121.html

**Solution**
Replaced '==' to 'is' when comparing to singletons
