### PR TITLE
Support fetch latest macOS

### DIFF
--- a/gibMacOS.py
+++ b/gibMacOS.py
@@ -81,7 +81,7 @@ class gibMacOS:
         catalog = kwargs.get("catalog", self.current_catalog).lower()
         catalog = catalog if catalog.lower() in self.catalog_suffix else "publicrelease"
         version = int(kwargs.get("version", self.current_macos))
-        url = "https://swscan.apple.com/content/catalogs/others/index-"
+        url = "https://swscan.apple.com/content/catalogs/others/index-12-10.16-"
         url += "-".join([self.mac_os_names_url[str(x)] if str(x) in self.mac_os_names_url else "10."+str(x) for x in reversed(range(self.min_macos, version+1))])
         url += ".merged-1.sucatalog"
         ver_s = self.mac_os_names_url[str(version)] if str(version) in self.mac_os_names_url else "10."+str(version)


### PR DESCRIPTION
```
#######################################################
 #                Downloading Catalog                  #
#######################################################

Currently downloading publicrelease catalog from

https://swscan.apple.com/content/catalogs/others/index-12-10.16-10.15-10.14-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog

Downloaded 6.89 MB of 6.89 MB (100.00%)
  #######################################################
 #                     gibMacOS                        #
#######################################################

Available Products:

1. macOS Big Sur 11.6.4 (20G417)
   - 002-65695 - Added 2022-02-17 18:41:29 - 12.45 GB
2. macOS Monterey 12.2.1 (21D62)
   - 002-66265 - Added 2022-02-17 18:38:45 - 12.16 GB
3. macOS Big Sur 11.6.3 (20G415)
   - 002-57023 - Added 2022-01-26 18:26:15 - 12.44 GB
4. macOS Monterey 12.2 (21D49)
   - 002-57041 - Added 2022-01-26 18:17:23 - 12.16 GB
5. macOS Big Sur 11.6.2 (20G314)
   - 002-42341 - Added 2022-01-14 18:44:26 - 12.44 GB
6. macOS Monterey 12.1 (21C52)
   - 002-42435 - Added 2022-01-14 18:42:59 - 12.16 GB
7. macOS Big Sur 11.6.1 (20G224)
   - 002-23589 - Added 2021-12-01 21:44:37 - 12.43 GB
8. macOS Monterey 12.0.1 (21A559)
   - 002-23774 - Added 2021-12-01 21:42:57 - 12.13 GB
9. macOS Big Sur 11.5.2 (20G95)
   - 071-78704 - Added 2021-08-18 18:28:53 - 12.45 GB
10. macOS Catalina 10.15.7 (19H15)
   - 001-68446 - Added 2020-11-11 17:48:09 - 8.75 GB
11. macOS Catalina 10.15.7 (19H4)
   - 001-57224 - Added 2020-10-27 17:28:13 - 8.75 GB
12. macOS Catalina 10.15.7 (19H2)
   - 001-51042 - Added 2020-09-24 17:09:31 - 8.75 GB
13. macOS Catalina 10.15.6 (19G2021)
   - 001-36801 - Added 2020-08-12 20:04:02 - 8.75 GB
14. macOS Catalina 10.15.6 (19G2006)
   - 001-36735 - Added 2020-08-06 23:39:24 - 8.75 GB
15. macOS Catalina 10.15.5 (19F2200)
   - 001-15219 - Added 2020-06-15 18:52:41 - 8.74 GB
16. macOS Catalina 10.15.4 (19E2269)
   - 001-04366 - Added 2020-05-04 15:32:04 - 8.75 GB
17. macOS Catalina 10.15.3 (19D2064)
   - 061-86291 - Added 2020-03-23 21:41:00 - 8.69 GB
18. macOS Mojave 10.14.4 (18E2034)
   - 041-88800 - Added 2019-10-23 14:41:18 - 6.53 GB
19. Install macOS High Sierra Beta 10.13.5 (17F66a)
   - 041-90855 - Added 2019-10-23 14:41:18 - 5.69 GB
20. macOS High Sierra 10.13.6 (17G66)
   - 041-91758 - Added 2019-10-19 18:19:55 - 5.71 GB
21. macOS Mojave 10.14.6 (18G103)
   - 061-26589 - Added 2019-10-14 20:51:08 - 6.52 GB
22. macOS Mojave 10.14.5 (18F2059)
   - 061-26578 - Added 2019-10-14 20:38:26 - 6.52 GB

M. Change Max-OS Version (Currently 10.15)
C. Change Catalog (Currently publicrelease)
I. Only Print URLs (Currently False)
S. Set Current Catalog to SoftwareUpdate Catalog
L. Clear SoftwareUpdate Catalog
R. Toggle Recovery-Only (Currently Off)
U. Show Catalog URL
Q. Quit

Please select an option:
```