### PR TITLE
Add aria2c downloader support for faster downloads

### DIFF
--- a/gibMacOS.py
+++ b/gibMacOS.py
@@ -93,13 +93,16 @@ class gibMacOS:
             "RecoveryHDUpdate.pkg",
             "RecoveryHDMetaDmg.pkg"
         )
+        self.use_aria2c = self.settings.get("use_aria2c", self.d.check_aria2c())
+        self.d.set_use_aria2c(self.use_aria2c)
         self.settings_to_save = (
             "current_macos",
             "current_catalog",
             "print_urls",
             "find_recovery",
             "hide_pid",
-            "caffeinate_downloads"
+            "caffeinate_downloads",
+            "use_aria2c"
         )
         self.mac_prods = []
 
@@ -659,6 +662,8 @@ class gibMacOS:
             lines.append("L. Clear SoftwareUpdate Catalog")
             lines.append("F. Caffeinate Downloads to Prevent Sleep (Currently {})".format("On" if self.caffeinate_downloads else "Off"))
         lines.append("R. Toggle Recovery-Only (Currently {})".format("On" if self.find_recovery else "Off"))
+        if self.d.check_aria2c():
+            lines.append("A. Toggle aria2c Downloader (Currently {})".format("On" if self.use_aria2c else "Off"))
         lines.append("U. Show Catalog URL")
         lines.append("Q. Quit")
         lines.append(" ")
@@ -706,6 +711,10 @@ class gibMacOS:
             self.save_settings()
         elif menu[0].lower() == "r":
             self.find_recovery ^= True
+            self.save_settings()
+        elif menu[0].lower() == "a" and self.d.check_aria2c():
+            self.use_aria2c ^= True
+            self.d.set_use_aria2c(self.use_aria2c)
             self.save_settings()
         if menu[0].lower() in ["m","c","r"]:
             self.resize()


### PR DESCRIPTION
## Summary
- Integrated optional aria2c downloader for multi-threaded, faster downloads
- Auto-detects aria2c availability and falls back to default downloader when not present
- Added menu toggle option A to switch between downloaders when aria2c is available

## Changes
- Modified Scripts/downloader.py to add aria2c support with automatic fallback
- Updated gibMacOS.py to add toggle option and persist user preference
- Preserves all existing functionality - completely backwards compatible

## Benefits
- Significantly faster downloads when aria2c is available (uses 16 concurrent connections)
- Automatic resume support for interrupted downloads
- No breaking changes - works exactly as before if aria2c is not installed

## Test plan
- Test with aria2c installed - verify faster downloads
- Test without aria2c - verify fallback to default downloader
- Test toggle functionality in main menu
- Verify settings persistence across sessions

🤖 Generated with [Claude Code](https://claude.ai/code)